### PR TITLE
Improve WordPress coding standards compliance

### DIFF
--- a/fmt.stub.php
+++ b/fmt.stub.php
@@ -6885,17 +6885,33 @@ EOT;
     final class WP {
         public static function decorate(CodeFormatter $fmt) {
             $fmt->enablePass('PSR2KeywordsLowerCase');
-            $fmt->enablePass('PSR2IndentWithSpace');
+            $fmt->disablePass('PSR2IndentWithSpace');
             $fmt->enablePass('PSR2LnAfterNamespace');
-            $fmt->enablePass('PSR2CurlyOpenNextLine');
+            $fmt->disablePass('PSR2CurlyOpenNextLine');
             $fmt->enablePass('PSR2ModifierVisibilityStaticOrder');
             $fmt->enablePass('PSR2SingleEmptyLineAndStripClosingTag');
             $fmt->enablePass('ReindentSwitchBlocks');
             $fmt->enablePass('ReindentEnumBlocks');
             $fmt->disablePass('ReindentComments');
-            $fmt->disablePass('StripNewlineWithinClassBody');
+            $fmt->enablePass('StripSpaceWithinControlStructures');
             $fmt->enablePass('WPResizeSpaces');
             $fmt->disablePass('ResizeSpaces');
+            $fmt->disablePass('EncapsulateNamespaces');
+            $fmt->enablePass('SpaceAroundControlStructures');
+            $fmt->enablePass('SpaceAfterExclamationMark');
+            $fmt->enablePass('SpaceAroundParentheses');
+            $fmt->enablePass('LongArray');
+            $fmt->disablePass('ShortArray');
+            $fmt->enablePass('MergeElseIf');
+            $fmt->disablePass('SplitElseIf');
+            $fmt->enablePass('ExtraCommaInArray');
+            $fmt->disablePass('StripExtraCommaInArray');
+            $fmt->enablePass('YodaComparisons');
+            $fmt->enablePass('AddMissingParentheses');
+            $fmt->enablePass('AutoPreincrement');
+            $fmt->enablePass('AlignGroupDoubleArrow');
+            $fmt->disablePass('AlignDoubleArrow');
+            $fmt->enablePass('AlignEquals');
         }
     }
 


### PR DESCRIPTION
Improve the WordPress (WP) coding standards formatter (`--wp` flag) to achieve closer compliance with the official WordPress PHP Coding Standards. While full parity isn’t possible with existing formatters, this configuration achieves close to full coverage.

### Changes ###

Expanded the `WP` class in `fmt.stub.php` with rules for additional formatting passes.

#### Disabled PSR-2 Rules ####
- `PSR2IndentWithSpace`: WP uses real tabs, not spaces for indentation.
- `PSR2CurlyOpenNextLine`: WP uses same-line braces.

#### Added WordPress Rules ####
- `LongArray` / disable `ShortArray`: WP prescribes long `array()` syntax instead of short `[]` due to readability and beginner friendliness.
- `MergeElseIf` / disable `SplitElseIf`: Due to colon syntax compatibility, `elseif` is preferred.
- `ExtraCommaInArray` / disable `StripExtraCommaInArray`: Trailing commas are recommended for easier reordering and cleaner diffs.
- `YodaComparisons `: Left-side constant placement is advised for `==`, `!=`, `===` and `!==` conditions `(5 === $value)`, but not for `<`, `>`, `<=`, `>=`. While not 100% compliant, enforcing yoda conditions expresses WP intent better.
- `SpaceAroundControlStructures`, `SpaceAfterExclamationMark`, `SpaceAroundParentheses`: WP uses spaces in control structures and around operators: `if ( ! $condition )`, `array( 1, 2, 3 )`, `foo() && bar()`.
- `AutoPreincrement`: WP favors pre-increment (`++$a`) and pre-decrement (`--$a`) forms to post-increment/decrement (`$a++ `/ `$a--`) due to performance and bug prevention.
- `AddMissingParentheses`: Parentheses must be used for instantiation `new Foo()`.
- `AlignEquals`: WP uses spaces to align consecutive lines of code for readability.
- `AlignGroupDoubleArrow` / disable `AlignDoubleArrow`: Alignment is determined contextually within code blocks.
- disable `EncapsulateNamespaces`:  Curly brace syntax not allowed for namespace declarations.
- `StripSpaceWithinControlStructures`: WP encourages brace style without empty lines.

#### Removed Rules ####
- `StripNewlineWithinClassBody`: Not required by WP coding standards.

### Motivation ###

The original WordPress standards implementation (#33) provided only partial support and used some inconsistent PSR-2 defaults. This update expands the rule set for near-complete compliance with the WordPress PHP Coding Standards, making the formatter more reliable for WordPress plugin and theme developers.

### References ###
- [WordPress PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
- Original implementation: #33